### PR TITLE
chore: fix broken mobile logo 🦖

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -24,6 +24,7 @@ const Layout = ({ location, children }) => {
   mobileLogo: file(absolutePath: {regex: "/FfT_Logo_Mobile.png/"}) {
     childImageSharp {
       gatsbyImageData(
+        width: 300
         quality: 100
         placeholder: BLURRED
         formats: [AUTO, WEBP, AVIF]
@@ -36,7 +37,7 @@ const Layout = ({ location, children }) => {
 
 const logos = withArtDirection(getImage(data.mobileLogo), [
   {
-    media: "(min-width: 768px)",
+    media: "(min-width: 765px)",
     image: getImage(data.desktopLogo),
   },
 ])
@@ -44,14 +45,22 @@ const logos = withArtDirection(getImage(data.mobileLogo), [
   if (location.pathname === rootPath) {
     header = (
       <div class="px-4 mb-6 md:ml-20">
-        <GatsbyImage image={logos} alt="Fallfish Tenkara" />
+        <GatsbyImage 
+          image={logos} 
+          alt="logo"
+          objectFit='scale-down'
+        />
       </div>
     )
   } else {
     header = (
       <div class="px-4 mb-6 md:ml-20">
         <Link to={`/`}>
-          <GatsbyImage image={logos} alt="Fallfish Tenkara" />
+          <GatsbyImage 
+            image={logos} 
+            alt="logo"
+            objectFit='scale-down' 
+          />
         </Link>
       </div>
         


### PR DESCRIPTION
I created this minimum reproduction for [this](https://github.com/gatsbyjs/gatsby/issues/31775) bug report

I added `objectFit='scale-down'` to the `<GatsbyImage>` component and the mobile logo now renders correctly.

I also confirmed this solution works for the `<StaticImage>` component as well ([code example](https://github.com/Isaac-Tait/Royal-Ridges-Retreat/blob/main/src/components/homePage.js))